### PR TITLE
chore(deps): bump jetty-server from 9.4.56 to 9.4.57.v20241219

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
 
         <!-- Test -->
         <cxf.version>3.5.4</cxf.version>
-        <jetty.version>9.4.56.v20240826</jetty.version>
+        <jetty.version>9.4.57.v20241219</jetty.version>
         <assertj.version>3.24.2</assertj.version>
         <junit.version>4.13.2</junit.version>
         <logback.version>1.2.13</logback.version>


### PR DESCRIPTION
## Summary
- Bumps `jetty-server` from **9.4.56.v20240826** to **9.4.57.v20241219** (latest patch on the 9.4.x line).
- Jetty is **test-scope only** here (mock WS endpoints in `SecureWSConnectorTest`), so there is no runtime impact on the connector.
- Addresses Pablo's review request from the Slack PR follow-up.

## Test plan
- [x] `mvn test` — 15/15 pass locally
- [ ] CI green